### PR TITLE
[SE-4181] Optimize shell script

### DIFF
--- a/chkrootkit
+++ b/chkrootkit
@@ -311,7 +311,7 @@ lkm ()
     prog=""
     if [  \( "${SYSTEM}" = "Linux"  -o \( "${SYSTEM}" = "FreeBSD" -a \
        `echo ${V} | ${awk} '{ if ($1 > 4.3 || $1 < 6.0) print 1; else print 0 }'` -eq 1 \) \) -a "${ROOTDIR}" = "/" ]; then
-       [  -x ./chkproc -a "`find /proc 2>/dev/null| wc -l`" -gt 1 ] && prog="./chkproc"
+       [  -x ./chkproc -a "`find /proc -maxdepth 1 2>/dev/null| wc -l`" -gt 1 ] && prog="./chkproc"
       [  -x ./chkdirs ] && prog="$prog ./chkdirs"
       if [ "$prog" = "" -o ${mode} = "pm" ]; then
          echo "not tested: can't exec $prog"


### PR DESCRIPTION
On busy servers, running `find /proc` with no flags can not only take a
relatively long time, but may cause `proc_inode_cache` in slab to
balloon, which in turn may force the kernel to go on an OOM killing
spree.

Since this is only required to check that chkrootkit is running on a
live system, limit the `find` run to only the `/proc`'s immediate
children.